### PR TITLE
chore: リンク先urlを変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
                     href="https://www.irasutoya.com/2013/09/blog-post_5250.html">白い卵のイラスト
                     -
                     いらすとや</a><br>
-                Icon svg by <a href="https://hiratake.xyz">Hiratake</a></div>
+                Icon svg by <a href="https://hiratake.dev/">Hiratake</a></div>
         </main>
     </body>
 </html>


### PR DESCRIPTION
リンク先のドメインを `hiratake.xyz` から `hiratake.dev` に変更しています。